### PR TITLE
Define charge threshold for complete charge

### DIFF
--- a/firmware/regenbox/regenbox.ino
+++ b/firmware/regenbox/regenbox.ino
@@ -111,13 +111,13 @@ void reportVoltage() {
   voltage_mesure = getVoltage(SENSOR_PIN_2);
   Serial.print("Tension pile emplacement 2 : "); 
   Serial.println(voltage_mesure);
-  //voltage_mesure = getVoltage(SENSOR_PIN_3);
-  //Serial.print("Tension pile emplacement 3 : "); 
-  //Serial.println(voltage_mesure);
-  //voltage_mesure = getVoltage(SENSOR_PIN_4);
-  //Serial.print("Tension pile emplacement 4 : "); 
-  //Serial.println(voltage_mesure);
-  //Serial.println("mV;");
+  voltage_mesure = getVoltage(SENSOR_PIN_3);
+  Serial.print("Tension pile emplacement 3 : "); 
+  Serial.println(voltage_mesure);
+  voltage_mesure = getVoltage(SENSOR_PIN_4);
+  Serial.print("Tension pile emplacement 4 : "); 
+  Serial.println(voltage_mesure);
+  Serial.println("mV;");
 #endif // MULTIPLE_SENSOR
 }
 

--- a/firmware/regenbox/regenbox.ino
+++ b/firmware/regenbox/regenbox.ino
@@ -269,14 +269,15 @@ void modeCharge() {
   if ((currentMillis - gPreviousMillis) >= ONE_MINUTE) {
    reportVoltage();
    gPreviousMillis = currentMillis;
-   // TODO : Define the strategy to stop charge !
   }
+  
   unsigned long voltage = getVoltage(SENSOR_PIN_1);
   if (voltage >= COMPLETE_CHARGE_THRESHOLD) {
     Serial.println("Fin de la charge");
     setRegenBoxMode(RBX_MODE_IDLE);
   }
 #ifndef OFFICIAL_TEST
+#ifdef MULTIPLE_SENSORS
   unsigned long voltage2 = getVoltage(SENSOR_PIN_2);
   if (voltage2 >= COMPLETE_CHARGE_THRESHOLD) {
     Serial.println("Fin de la charge");
@@ -294,7 +295,8 @@ void modeCharge() {
 //    Serial.println("Fin de la charge");
 //    setRegenBoxMode(RBX_MODE_IDLE);
 //  }
-#endif
+#endif // MULTIPLE_SENSORS
+#endif // OFFICIAL_TEST
 }
 
 //-----------------------------------------------------------------------------

--- a/firmware/regenbox/regenbox.ino
+++ b/firmware/regenbox/regenbox.ino
@@ -15,8 +15,9 @@
 #define CHARGE_THRESHOLD       1500      // Seuil limite de charge de la pile
 #define DECHARGE_THRESHOLD      900      // Seuil de decharge
 #define DEAD_THRESHOLD          688      // Seuil de mort de la pile pour l'arret des cycles de charge/decharge
-#define OFFICIAL_TEST
-//#define MULTIPLE_SENSORS
+//#define OFFICIAL_TEST
+#define COMPLETE_CHARGE_THRESHOLD 1650
+#define MULTIPLE_SENSORS
 #define VOLTAGE_HISTORY_NUM       5      // Nombre d'echantillons sauvegardés dans l'historique
 
 enum RBX_STATUS {
@@ -110,12 +111,12 @@ void reportVoltage() {
   voltage_mesure = getVoltage(SENSOR_PIN_2);
   Serial.print("Tension pile emplacement 2 : "); 
   Serial.println(voltage_mesure);
-  voltage_mesure = getVoltage(SENSOR_PIN_3);
-  Serial.print("Tension pile emplacement 3 : "); 
-  Serial.println(voltage_mesure);
-  voltage_mesure = getVoltage(SENSOR_PIN_4);
-  Serial.print("Tension pile emplacement 4 : "); 
-  Serial.println(voltage_mesure);
+  //voltage_mesure = getVoltage(SENSOR_PIN_3);
+  //Serial.print("Tension pile emplacement 3 : "); 
+  //Serial.println(voltage_mesure);
+  //voltage_mesure = getVoltage(SENSOR_PIN_4);
+  //Serial.print("Tension pile emplacement 4 : "); 
+  //Serial.println(voltage_mesure);
   //Serial.println("mV;");
 #endif // MULTIPLE_SENSOR
 }
@@ -271,6 +272,30 @@ void modeCharge() {
    gPreviousMillis = currentMillis;
    // TODO : Define the strategy to stop charge !
   }
+  unsigned long voltage = getVoltage(SENSOR_PIN_1);
+  if (voltage >= COMPLETE_CHARGE_THRESHOLD) {
+    Serial.println("Fin de la charge");
+    setRegenBoxMode(RBX_MODE_IDLE);
+  }
+#ifndef OFFICIAL_TEST
+  unsigned long voltage2 = getVoltage(SENSOR_PIN_2);
+  if (voltage2 >= COMPLETE_CHARGE_THRESHOLD) {
+    Serial.println("Fin de la charge");
+    setRegenBoxMode(RBX_MODE_IDLE);
+  }
+
+//  unsigned long voltage3 = getVoltage(SENSOR_PIN_3);
+//  if (voltage3 >= COMPLETE_CHARGE_THRESHOLD) {
+//    Serial.println("Fin de la charge");
+//    setRegenBoxMode(RBX_MODE_IDLE);
+//  }
+//
+//  unsigned long voltage4 = getVoltage(SENSOR_PIN_4);
+//  if (voltage4 >= COMPLETE_CHARGE_THRESHOLD) {
+//    Serial.println("Fin de la charge");
+//    setRegenBoxMode(RBX_MODE_IDLE);
+//  }
+#endif
 }
 
 //-----------------------------------------------------------------------------


### PR DESCRIPTION
Define a threshold to charge battery, the limit is defined to 1650 mV  and can be changed by modifying the define COMPLETE_CHARGE_THRESHOLD. The voltage can be controlled on the other slots if the regenbox has been modified to connect JP3 to A1 JP5 to A2 and JP7 to A3.